### PR TITLE
Changes to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ The XBlock can interface to both:
 The necessary settings for a server should be set provided using the course's "Other course settings" JSON object, so it is available to all problems in a course, and can be centerally modified for them all.
   - The code also supports providing the server configuration/authentication data in each problems, but doing so is highly discouraged.
 
+## Installation
+
+For installation instructions in an edX devstack on the "lilac" named release see: https://github.com/Technion-WeBWorK/xblock-webwork/blob/edx-named-release-install/install-docs/setup-devstack-named-release-with-webwork-xblock.md . Those settings were tested on July 30, 2021 and were used to bring up a new test system.
+
+Older instructions for installing in the "master" branch of devstack are in the directory https://github.com/Technion-WeBWorK/xblock-webwork/blob/edx-named-release-install/install-docs/ but are not fully updated. In particular, they are missing instructions on enabling the "Other course settings" option and using it to configure the XBlock course-wide settings.
+
+**Warning:** The "master" branch of devstack also is making a transition from the "old" LMS system to new services, and that apparently may cause some problems with the instructions, which worked before those changes.
+
 ## Feature overview
 
 ### Course level configutation
@@ -83,3 +91,6 @@ The necessary settings for a server should be set provided using the course's "O
 * The remote back-end WeBWorK systems are not sent personal identification information from the edX student data about the students.
   * Requests send only the necessary data to render/grade a problem to the back-end.
   * For grading of answers, this includes whatever data a student typed into the input boxes of a WeBWorK question.
+
+Additional information on the design can be found in https://github.com/Technion-WeBWorK/xblock-webwork/blob/edx-named-release-install/doc/Design.md
+

--- a/doc/Design.md
+++ b/doc/Design.md
@@ -1,0 +1,124 @@
+# WeBWorK XBlock design
+
+## Introduction
+
+WeBWorK is an open-source computer-aided assessment system designed to support problems in mathematics, and related disciples.
+
+Recent versions of the WeBWorK system (the `html2xml` subsystem), and the Standalone renderer https://github.com/drdrew42/renderer provide APIs which allow WeBWorK problems to be embedded in external systems.
+
+The WeBWorK XBlock is designed to leverage those capabilities to allow embedding WeBWorK problems in an Open edX based MOOC course.
+
+## Architecture
+
+The WeBWorK XBlock is designed to function as a Man in the Middle (MiTM) system, where all end-user (student) interactions is carried out in direct communications with the Open edX server, including the loading of the main problem content, and the submission of answers to be graded. The XBlock running inside the Open edX server will manage all user state information (student identity, scores, parameters related to the problem assigned, answers submitted) and will communicate with a back-end WeBWorK problem renderer to retrieve the problem text and data, to submit answers received from a student, and to retrieve the feedback and score for such submissions. The relevant data will be sent back to the end user's browser.
+
+The WeBWorK problems will be enclosed in an iFrame, where the main problem text will be pushed into the iFrame via the `srcdoc` attribute using a JavaScript handler. The JavaScript code outside the XBlock will inform the `submit` buttons inside the iFrame to pass submissions to a JavaScript function running in the encapsulating web page, and that JavaScript handler will initiate an AJAX call to the relevant handler routine on the Open edX server. The internal iFrame will be retreive all additional resources required (JavaScript code, CSS styling, images, etc.) from the relevant web locations as instructed to by the HTML code of a problem. The initial problem loading will also be done via the same type of AJAX call, whereby enabling the main page structure to load quickly, and deferring the calls to the WeBWorK back-end to be handled later on during the page load process.
+
+The XBlock users the XBlock Fields API, and in particular fields with Scope.user_state to manage and persist data related to an individual students use of a problem, including the (best) score earned, the number of graded submissions processed, etc.
+
+## Learner privacy and security aspects
+
+The XBlock running on the Open edX server will not provide any personal identification information (name, email, user ID, etc.) to the WeBWorK problem renderer being called.
+
+However, as certain types of WeBWorK problems can depend on a `psvn` parameter, which is typically fixed for a given student within the framework of a "problem set", a feature which allows sequences of problems to share a common seed for randomization, that parameter can be used to some extent to identify (group) learners. Both to allow additional flexibility in terms of the use of `psvn` dependent problems and to allow somewhat mitigating the "fingerprint" created by the `psvn` parameter, the XBlock allows a user to have several indexed `psvn` values, and different problems/problem groups can request a different `psvn` value be used.
+
+## Core capabilities
+
+* The settings for the back-end problem renderer are typically configured using the "Other course settings" JSON object, so main settings can be edited at the course level.
+  * The capability to provide such settings for individual problems exists, but use of that capability is not recommended.
+
+* The `studio_view` method allows the course author to edit the relevant settings (of type Scope.settings), and does validation of the fields for which reasonable local validation is possible.
+  * Settings whose validation requires contact with the remote WeBWorK server are not validated.
+    * This includes authentication data, the `problem` name (the path to the problem file used on the backend), ???
+  * The language in which back-end generated strings (from outside the problem code) such as score messages should be generated. That setting effects the back-end behavior and depends on there being a suitable `.po` file on the backend. (Setting `ww_language`) The standalone renderer does not yet support this.
+  * Main settings:
+    * `problem` = path to problem file on the back-end.
+    * `max_allowed_score` = total number of points the problem can earn.
+    * `ww_language` = language used for "system" messages by the back-end system.
+    * `max_attempts` = maximum number of for-credit submissions allowed. (0 for unlimited)
+    * `weight` = the weight of the problem (when different problem grades are merged by Open edX for a section grade)
+    * `psvn_key` = which `psvn` to use from the set of such values for each given user.
+      * Allows some problems to use a `psvn` of key 1, others to use one of key 2, etc.
+    * Settings related to controlling which back-end server is contacted.
+    * Settings which control when and whether correct answers, hints, and solutions are made available.
+    * Several technical settings related to the display / processing of the problem.
+
+* The XBlock permits problems to have a deadline or not.
+  * When there is a deadline:
+    * For credit submission are allowed until the deadline + the standard grace period allowed.
+    * Submission to the problem will be locked for a configurable number of hours after the grace period, after which submissions are again allowed, receive full feedback, but the recorded score is not updated.
+    * Viewing the correct answers is only allowed in the "post deadline" period.
+  * When there is no deadline:
+    * For credit submission are allowed until the permitted attempt limit is exceeded.
+    * After that, submissions are allowed, receive full feedback, but the recorded score is not updated.
+    * Viewing the correct answers is allowed after all graded submissions are made, or after suitable many attempts are made.
+  * The handling of the different cases in handled using the `PPeriods` and `WWProblemPeriod` classes.
+  
+* Problems can limit the number of graded submissions permitted or not.
+  * Graded attempts are counted by the XBlock using both a simple counter, and a pair of counters similar to the data expected by the back-end systems.
+
+* The most critical method is `submit_webwork_iframed` which handles all the AJAX calls from the client side.
+  * It contains the logic to determine what actions are permitted and to carry them out by making a suitable call the the external WeBWorK problem renderer.
+  * It managed parsing the reply from the back-end server and preparing the reply to send to the end user's browser.
+  * This code is quite detailed to cover all the deadline/attenmpts state conditions which determine when a given action request is permitted.
+  * Other than initial setup, the code handles both possible back-end server types at once.
+
+* Messages are generated to display the current and recorded best score, the number of attempts allowed and used so far, etc.
+
+* The XBlock will provide information to the AJAX calls about which submission buttons should be active and which should be disabled.
+  * In any case, the code also verifies and prevents use of capabilities which are not currently intended to be available to the end user. (For example, a "Show Correct Answers" submission will not be processed when it is not permitted and will instead trigger a suitable message to be diplayed to the end user.
+
+* Data on submitted answers will be stored using the extended `CSMH` in a similar manner to standard Open edX problems.
+  * The XBlock code attempts to carefully select which answer related data provided by the WeBWorK server is persisted, and uses Python dictionaries to collect the names of keys to be saved.
+  * At present it is necessary to make 2 very small modifications to enable the WeBWorK XBlock to use that facility, on to enable storing the data, and one to automatically enable course staff to view the submissions using the same preexisting facilty as used by `problem`.
+  * A small change to make configuring which XBlocks can use those feature via the system configuration files was developed.
+     * We intend to submit a pull request with those small changes to the core project.
+  * Some experimentation was done with persisting the submissions using the `submissions` API, and commented out code to use that alternative was left in the code for possible use in the future.
+
+* The `student_view` method and the main `html` fragment file and `js` file are quite small, as problem loading is done via an AJAX call similar to that used to submit answers, etc.
+  * There is a capability to display some debugging information colleced into a JSON object in this method, and commented out sample code.
+
+## Additional technical details
+
+### Basic sanitization of submitted data
+* AJAX calls are sanitized to remove potential form keys which have an operation meaning in the WeBWorK renderer backends, so that only settings intentionally set by the XBlock will be sent to the back-end WeBWorK problem renderer.
+  * Ongoing maintenance of the list of keys to be cleared is necessary as new keys may be added to the rendering servers.
+
+### `show_in_read_only_mode`
+`show_in_read_only_mode` is enabled, so staff can see the version of a problem assigned to a given student.
+
+### `unique_id`
+
+A `unique_id` of score `Scope.user_state` is used to identify HTML elements belonging to a given problem, so the JavaScript methods used when processing the reply to an AJAX call can modify the data in the correct locations on the page (that belonging to the correct problem).
+
+### Calls to the backend servers are routed via
+  * `request_webwork_standalone` (uses HTTP `POST`) and initial work to send the critical settings via an encrypted JWT was implemented. More work is needed on this.
+  * `request_webwork_html2xml`(uses HTTP `GET`)
+These are the only 2 methods via which calls to the back-end renderers can be made.
+
+They are called via `request_webwork` which adds some final settings to the request before one of those options is called.
+  * This prevents the need to make those settings in multiple locations elsewhere in the code.
+
+### Problem processing on the edX side
+* Extraction and processing of the HTML data is handled by `_problem_from_json`
+  * For the `html2xml` option relative URLS are modified based on the `server_static_files_url` setting to convert them to full URLS, so the resource will be loaded properly.
+* Extraction and processing of responses to AJAX calls, and in particular the collection of data to persist, is handled by
+  * `_result_from_json_standalone`
+  * `_result_from_json_html2xml`
+* These methods remain distinct as the `standalone_style` output of `html2xml` has some key differences from the JSON output format of the Standalone renderer.
+
+### ScorableXBlockMixin
+
+The XBlock implements several methods required by the `ScorableXBlockMixin`.
+
+### Internationalization
+* Initial work on internationalization so that the XBlock can prepare messages to the end users in different languages is being implemented.
+  * This being done in the manner recommended by the Open edX project using `.po` and `.mo` files, but in the initial phase in an ad-hoc manner.
+  * The initial version will support English and Hebrew.
+
+## Primary web resources from the WeBWorK project
+
+* https://openwebwork.org/
+* https://webwork.maa.org/
+* https://webwork.maa.org/wiki/WeBWorK_Main_Page
+* https://github.com/openwebwork

--- a/doc/course-level-settings.md
+++ b/doc/course-level-settings.md
@@ -17,49 +17,45 @@ object whose key is "webwork_settings".
       * Key = the "ww_server_id" which can be selected to use this group of settings.
       * Value is a object containing at least the following required settings per server:
         * "server_type" either "standalone" or "html2xml"
-        * "server_url" = the head portion of the URL where the API is.
+        * "server_api_url" = the head portion of the URL where the API is.
 	  * Examples:
 	    * "https://myserver.mydomain.tld/webwork2/html2xml"
 	    * "https://myserver.mydomain.tld:3000/render-api"
+        * For html2xml servers, there is also
+            * "server_static_files_url" which is prepended to URLs in the generated HTML,
+              as the man-in-the-middle architecture of loading HTML into the iFrame does
+              would not send relative URLS to the WeBWorK server otherwise.
+              Example value: "https://myserver.mydomain.tld/webwork2_files".
         * "auth_data" = object of key-value pairs needed for the authentication and
 	  secure communucations with the relevant server
           * for "server_type" = "html2xml" this includes:
 	    * "ww_course", "ww_username", "ww_password"
-          * for "server_type" = "standalone" this inlcudes:
-	    * nothing at present. FIXME to handle JWT secret, auth settings, etc.
+            * which are the settings used to authenticate to the daemon course on the server
+          * for "server_type" = "standalone" this includes:
+            * "aud" (which needs to match `SITE_HOST` set in `render.conf` for the renderer)
+            * "problemJWTsecret"
   * Fields in the "course_defaults" object:
     * "default_server" whose value is one of the entries in the prior array. (required)
-    * "default_show_answers" (boolean) should show answers be made available after
-      the relevant answer_delay.
-      (optional, default to true)
-    * "default_show_solutions" (boolean) should solutions (if they exist) be made available
-      after the relevant answer_delay.
-      (optional, default to true)
-    * "default_allow_hints" (boolean) should hints (if they exist) be permitted.
-      (optional, default to false)
-    * "default_post_deadline_lockdown" = # of minutes after the deadline during which
-       submissions are forbidden (except for the grace perion).
-       (optional, default to 2880 minutes = 48 hours)
-    * "default_answer_delay" = # of minutes after deadline when answers become
-       available to the students.
-       (optional, default to 2880 minutes = 48 hours)
-    * "default_html_lang" = default setting for the main LANG attribute inside the iFrame.
-       (optional, when not provided, the webwork server defaults will apply)
-    * "default_html_dir" = default setting for the main DIR attribute inside the iFrame.
-       (optional, when not provided, the webwork server defaults will apply)
-
+    * "psvn_shift" (optional) a numeric shift to apply in the current course to PSVN values,
+      as for technical reasons for each user they are system-wide values and not course-wide
+      values.
+    * Additional default settings were under consideration, but have not yet been implemented.
 
 Sample config, which is included inside the main JSON object.
 
+```
 {
     "webwork_settings": {
         "server_settings": {
             "LocalStandAloneWW": {
                 "server_type": "standalone",
                 "server_url": "http://standalone.domain.tld:3000/render-api",
-                "auth_data": {}
+                "auth_data": {
+                    "aud": "http://standalone.domain.tld:3000",
+                    "problemJWTsecret": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                }
             },
-            "TechnionWW2": {
+            "RemoteHtml2xml": {
                 "server_type": "html2xml",
                 "server_url": "https://webwork.domain.tld/webwork2/html2xml",
                 "auth_data": {
@@ -71,23 +67,15 @@ Sample config, which is included inside the main JSON object.
         },
         "course_defaults": {
             "default_server": "LocalStandAloneWW",
-            "default_show_answers": true,
-            "default_show_solutions": false,
-            "default_allow_hints": false,
-            "default_post_deadline_lockdown": 1440,
-            "default_answer_delay": 2880,
-            "default_html_lang": "he",
-            "default_html_dir": "rtl"
+            "psvn_shift": 51
         }
     }
 }
-
+```
 
 References on the "Other course settings feature":
-  https://www.edunext.co/articles/discover-open-edx-ironwood
-  https://github.com/edx/edx-platform/pull/17699
-  https://openedx.atlassian.net/browse/OSPR-2303
-  https://github.com/edx/edx-documentation/pull/1702
-
-
+  - https://www.edunext.co/articles/discover-open-edx-ironwood
+  - https://github.com/edx/edx-platform/pull/17699
+  - https://openedx.atlassian.net/browse/OSPR-2303
+  - https://github.com/edx/edx-documentation/pull/1702
 

--- a/doc/xblock-level-settings.txt
+++ b/doc/xblock-level-settings.txt
@@ -5,7 +5,7 @@ WAS GLOBAL - BEING REPLACED:
   SERVERTYPE
 
 "Global"
-  main_settings   = the JSON config data retreived from the course
+  main_settings   = the JSON config data retrieved from the course
 
 XBlock fields
 
@@ -23,52 +23,55 @@ XBlock fields
 
     For use when in manual mode - otherwise should be left as None and kept invisible
       server_type
-      server_url
+      server_api_url
+      server_static_files_url
       auth_data - when needed should be a JSON dictionary of the needed settings
         *** replacing 'ww_course', 'ww_username', 'ww_password' for html2xml mode
+        *** for standalone mode now needs 'aud' and 'problemJWTsecret'
         *** help data should explain what is needed or FIXME + promise to explain
 
   Problem - main settings
     problem = Path for WW problem file (as expected on the WW server)
-    max_allowed_score
+    max_allowed_score = Scores are scaled from the WeBWorK 0-1 range to 0-max_allowed_score.
     max_attempts
+    no_attempt_limit_required_attempts_before_show_answers = controls when to allow viewing answers when no deadline and unlimited attempts
+    weight = weight of problem in unit (edX standard field)
+    settings_type = controls whether to use course-wide settigs about the remote server or ones set by the problem
+    ww_server_id = which serverID to use from the course-wide settigs
+    ww_server_type, ww_server_api_url, ww_server_static_files_url, auth_data = problem specific server settings (not recommended, use course-wide settings instead)
 
   Problem - display related settings
+    ww_language = used to set the language of the translation dictionary to use on the WeBWorK side. (Currently only supported by html2xml as there are no dictionaries yet for the standalone renderer.)
+
+    # Probably do not need to be edited
     display_name
     iframe_min_height
     iframe_max_height
     iframe_min_width
-    unique_id
 
-  Problem - special settings - can be left as None
+  Problem - special settings - can usually be left with the default values
+    allow_show_answers
+    allow_ww_hints
+    allow_ww_solutions_with_correct_answers
+    problem_banner_text
+    webwork_request_timeout
+    post_deadline_lockdown
 
-    course_grace_period_minutes = # of minutes to allow after deadline - course level
-    problem_additional_grace_period_minutes = # of additional minutes for this problem
-    student_additional_grace_period_hours = # of additional hours for this student on all problems
-    student_problem_additional_grace_period_minutes = # of additional hours for this student on this problem
 
-    problem_answer_delay = # of minutes after deadline when answers become available, when set overrides the
-      course level default_answer_delay
-
-    problem_show_answers = should show answers be made available after the relevant answer_delay
-      To override the course wide default_show_answers
-    problem_answer_delay = # of minutes after deadline when answers become available, when set overrides the
-      course level default_answer_delay
-
-    problem_html_lang = overrode default_html_lang
-    problem_html_dir = overrode default_html_dir
-
-    custom_parameters
+    custom_parameters = for future use
 
   User state for problem:  (Scope.user_state)
     student_answer
-    student_attempts # CHANGE to be like WW
-      student_numCorrect
-      student_numIncorrect
-    student_score
+    student_attempts = total, but we also store ww_numCorrect, ww_numIncorrect (as Standalone uses them)
+    best_student_score
     seed
     psvn_index = index number of which PSVN to use for this instance of the problem
-      * Used to pull a value out of psvn_array
+      * Used to pull a value out of psvn_options (a Dict)
+    submission_data_to_save (answers, etc. which get saved)
+    student_viewed_correct_answers
+    unique_id (internal, used to prevent identify iFrames, divs, etc. of different problems)
+
+    done, last_submission_time - based on capa_module.py
 
     MAYBE:
       last_answer = WW format to allow reloading prior answers during initial rendering. Needs support on the standalone side

--- a/install-docs/devstack-install-and-debug.md
+++ b/install-docs/devstack-install-and-debug.md
@@ -13,6 +13,14 @@ copy-paste in document up to need
 <span style="color:#f7f7f7">Faded text</span>  
 -->
 
+**Warning:** Recent changes to the master branches of devstack and the edX codebase seem to interfere
+with using the "master" branches, which did work until relatively recently. For now, we recommend installing
+using a "named" release as explained in:
+https://github.com/Technion-WeBWorK/xblock-webwork/blob/edx-named-release-install/install-docs/setup-devstack-named-release-with-webwork-xblock.md
+and then following the instructions below to set up the debugging tools.
+
+---
+
 # 1. Preliminaries
 This Tutorial should help the reader to install xblock-webwork into Open edX's full devstack environment and debug it with VS-Code.
 
@@ -147,11 +155,19 @@ Change it to your needs when following the instructions
        <img src="Edx-Devstack-Settings.png" alt="drawing" width="500"/>
     + In the Advanced Module List field, place your cursor between the braces, add a comma and then type "webwork":  
         <img src="Edx-Devstack-Advanced-Module-List.png" alt="drawing" width="500"/>
-    + Save the settings  
+    + Save the settings
+    + See below. It is now necessary to enable and use "Other course settings" or the XBlock will not fully work.
+      + Problems using `settings_type` "Manual settings" and directly providing the corrrect server configuration
+        will probably work without "Other course settings". That approach is **not** recommended.
     + Navigate again to: Demonstration Course->view in studio->view live->view in studio
     + Scroll down and find Add New Component -> Advanced
       And choose your Webwork Problem -> done:  
        <img src="Edx-Devstack-Add-New-Component.png" alt="drawing" width="500"/>
+
+10. You need to set up the capability to use "Other course settings" and make the necessary settings
+there, in order to get a fully functioning XBlock. That is needed to allow making the course-wide
+settings, so server settings need not be set for each problem (which is not recommended).
+See https://github.com/Technion-WeBWorK/xblock-webwork/blob/edx-named-release-install/install-docs/setup-devstack-named-release-with-webwork-xblock.md
 
 # 4.  Debug the webwork-xblock in Lms/Studio containers with VS-Code
 These instructions are based on the  

--- a/install-docs/sdk-install-and-debug.md
+++ b/install-docs/sdk-install-and-debug.md
@@ -13,6 +13,12 @@ copy-paste in document up to need
 <span style="color:#f7f7f7">Faded text</span>  
 -->
 
+**Warning:** We have not used the XBlock SDK with the WeBWorK XBlock for a
+long time. Some features, in particular the course-level settings from
+"Other course settings" and settings related to deadlines, graceperiod,
+and probably more would not be available in the SDK. As a result, attempting
+to run the WeBWorK XBlock in the DSK is not recommended nor supported.
+
 # 1. Preliminaries
 This Tutorial should help the reader to install xblock-webwork into Open edX's limited xblock-sdk environment and debug it with VS-Code. Listed below xblock-sdk environment pros-and-cons when compared with Open edX-devstack environment:
 

--- a/install-docs/setup-devstack-docker-with-webwork-xblock.md
+++ b/install-docs/setup-devstack-docker-with-webwork-xblock.md
@@ -13,6 +13,15 @@ copy-paste in document up to need
 <span style="color:#f7f7f7">Faded text</span>  
 -->
 
+
+**Warning:** Recent changes to the master branches of devstack and the edX codebase seem to interfere
+with using the "master" branches, which did work until relatively recently. For now, we recommend installing
+using a "named" release as explained in:
+https://github.com/Technion-WeBWorK/xblock-webwork/blob/edx-named-release-install/install-docs/setup-devstack-named-release-with-webwork-xblock.md
+and then following the instructions below to set up the debugging tools.
+
+---
+
 The goal of this guide is to help you set up an environment with the edX Docker
 based devstack with the webwork XBlock installed it in.
 
@@ -134,6 +143,19 @@ Here I arbitrarily chosen **XblockEx** directory name
             sleep 2; done'
 
 + Save and exit
+
+## Enable and use "Other course settings"
+
+You need to set up the capability to use "Other course settings" and make the necessary settings
+there, in order to get a fully functioning XBlock. That is needed to allow making the course-wide
+settings, so server settings need not be set for each problem (which is not recommended).
+
+See https://github.com/Technion-WeBWorK/xblock-webwork/blob/edx-named-release-install/install-docs/setup-devstack-named-release-with-webwork-xblock.md
+where that was done for an install of the "lilac" named release in a devstack.
+
+**Note:** Problems using `settings_type` "Manual settings" and directly providing all the
+corrrect server configuration will probably work without "Other course settings".
+That approach is **not** recommended.
 
 ## 14. Enable the XBlock in Your Course:  
   + Typically it suffices to only start the LMS and Studio containers and their dependencies,

--- a/install-docs/setup-devstack-named-release-with-webwork-xblock.md
+++ b/install-docs/setup-devstack-named-release-with-webwork-xblock.md
@@ -5,7 +5,7 @@ Testing the WeBWorK XBlock requires:
 for the XBlock.
 
 The goal of this guide is to set up an functional test system using the Docker
-based edX devstack with the webwork XBlock installed it in, and a local install
+based edX devstack with the WeBWorK XBlock installed it in, and a local install
 of the WeBWorK standalone renderer.
 
 In order to make this test system reasonably stable, the devstack is being set
@@ -19,7 +19,7 @@ in the devstack.
 
 ## Hardware / software requirements
 
-The installation of the edx devstack depends on using Docker.
+The installation of the edX devstack depends on using Docker.
 
 The devstack requirements at https://github.com/edx/devstack#prerequisites
 lists Python 3.8 as a prerequisite, and Ubuntu 20.04 LTS provides this
@@ -45,7 +45,7 @@ We have been able to install the necessary portion of the devstack to test
 the XBlock and the additional components on a test system which had 16GB RAM
 using a Ubuntu partition of 50GB, and only about 30GB of disk space was used.
 However, that installation did not install the full devstack, only Studio
-and LMS and theie dependencies. A full devstack would certainly use more space.
+and LMS and their dependencies. A full devstack would certainly use more space.
 
 ## Assumptions in the process below.
 
@@ -115,7 +115,7 @@ The `docker` group was created to allow you to run Docker commands
 as your regular user. (This has security implications. See the Docker
 documentation.)
 
-That change is not fully active in your current login sesssion.
+That change is not fully active in your current login session.
 
 It is often easiest to log out and the log back in, so that the system will
 be aware that your user belongs to the `docker` group.
@@ -129,7 +129,7 @@ Test that docker is working (for the current user):
 ```
 # If necessary run:
 #           newgrp docker
-docker run hello-world  
+docker run hello-world
 # You should see the output from the test hello-world container.
 ```
 
@@ -138,9 +138,8 @@ docker run hello-world
 ### Primary sources:
 
 - The instructions below install under `~/XblockEx` which can be changed.
-- The official install instructions for devstack are at: 
+- The official install instructions for devstack are at:
   - https://github.com/edx/devstack
-0 
 - Documentation on install a named release of edX in the devstack are at
   - //github.com/edx/devstack/blob/master/docs/developing_on_named_release_branches.rst
   - **Warning:** The older instructions about this at https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-hawthorn.master/installation/install_devstack.html are apparently somewhat outdated, and the order of several steps there seem to be **incorrect**.
@@ -150,11 +149,11 @@ WeBWorK XBlock.
 
 ### Setting OPENEDX_RELEASE for the future:
 
-Using devstack with a named release requires that the `OPENEDX_RELEASE` 
+Using devstack with a named release requires that the `OPENEDX_RELEASE`
 environment variable be set before various commands are run. This is necessary
 both for the installation process, and in later use.
 
-Thus, please add the `export OPENEDX_RELEASE=lilac.master` line (included 
+Thus, please add the `export OPENEDX_RELEASE=lilac.master` line (included
 in the steps below) into your `.bashrc` file (or whatever file/command is
 needed if you are using a different shell) either now or after completing the
 installation. That will make the correct setting of this environment variable
@@ -196,7 +195,7 @@ make dev.checkout
 ```
 
 The next step takes some time. Sometimes errors occur during the next step,
-and that indicated that some of the devstack Docker image failed to 
+and that indicated that some of the devstack Docker image failed to
 be downloaded / installed. This seems to be caused by network issues, and
 gets resolved by running the command again. Thus, if you got any error,
 please run the command again (possibly several times) until all images are
@@ -215,11 +214,11 @@ the Docker images are properly downloaded.
 
 ---
 
-** The next step is known to take quite a bit of time.** After starting it, you
+**The next step is known to take quite a bit of time.** After starting it, you
 probably want to go do something else for a while (probably at least half an
 hour).
 
-** Alternatively, you might want to try to run the "Standalone render"
+**Alternatively**, you might want to try to run the "Standalone render"
 installation from 2 sections down in parallel to the next command.
 
 ```
@@ -244,8 +243,8 @@ For the devstack, the setting seems to need to be set in 2 files, as explained
 below.
 
 You should run the following steps while the devstack is still running
-(so you can copy the files out of the running containers to make 
-persistant local copies to edit). Do so inside the Python virtualenv which 
+(so you can copy the files out of the running containers to make
+persistent local copies to edit). Do so inside the Python virtualenv which
 should still be running from the prior stage (or start up the venv again).
 
 ```
@@ -315,7 +314,7 @@ docker logs edx.devstack-lilac.master.lms
 
 Hopefully you will now be able to open http://localhost:18000 in your web
 browser and see something like:
-    <img src="Edx-Devstack-Entry-Page.png" alt="drawing" width="500"/>  
+    <img src="Edx-Devstack-Entry-Page.png" alt="drawing" width="500"/>
 
 ## Install the WeBWorK XBlock and configure devstack to load it
 
@@ -335,7 +334,7 @@ git clone https://github.com/Technion-WeBWorK/xblock-webwork.git
 Next we are going to edit the devstack `docker-compose.yml` file so
 the devstack will reinstall and load the XBlock each time the devstack is
 brought up. This is necessary if the code is being modified. (You can use a
-differerent editor instead of `vim` but be careful not to break the required
+different editor instead of `vim` but be careful not to break the required
 formatting of the files being edited.)
 
 
@@ -346,13 +345,13 @@ vim docker-compose.yml
 ```
 
 1. Find the "command" line in the "lms:" section of the file.
-2. Make the copy of the original line into a commented out line 
+2. Make the copy of the original line into a commented out line
 by adding a `#` at the start of the line.
 3. In the active "command" line add the string `pip install /edx/app/edxapp/edx-platform/src/xblock-webwork/ &&` just before the `while true`.
-  - The `pip install` we added should be between an old `&&` and the new one added here.
+   - The `pip install` we added should be between an old `&&` and the new one added here.
 4. Repeat this process in the "studio:" section of the file.
 
-**Note:** If you want to use the IDE debugging features discussed in 
+**Note:** If you want to use the IDE debugging features discussed in
 https://github.com/Technion-WeBWorK/xblock-webwork/blob/master/install-docs/devstack-install-and-debug.md
 you would also want to add `pip install ptvsd` in a similar manner.
 As this guide is not addressing IDE debugging, that additional install is not
@@ -366,8 +365,8 @@ make dev.up.lms+studio
 
 ## Install and configure a local installation of the WeBWorK standalone renderer
 
-This step is somewhat independed of the prior 2 steps, and could be done
-in parallel to them, so long as the additional network load will not 
+This step is somewhat independent of the prior 2 steps, and could be done
+in parallel to them, so long as the additional network load will not
 interfere with the other installation steps.
 
 ### Installation:
@@ -415,20 +414,20 @@ work.
     the Standalone renderer side from a string, we recommend using only 7-bit
     ASCII characters, to avoid any problems with character-set related
     conversions leading to the value not being properly received.
-  - For the sample testing, please use 
+  - For the sample testing, please use
     `problemJWTsecret => 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'` or make sure to
-     set the same value in this file and in the configration later added to 
+     set the same value in this file and in the configuration later added to
      the "Other course settings" in edX Studio.
 
 **Warning:** for local use of the Standalone renderer with edX devstack
 on a single computer, you should **not** replace the value of `SITE_HOST`
 in the `render_app.conf` file. It should remain `http://localhost:3000` as
-your browser will be loading auxilliary files needed by WeBWorK problems from
+your browser will be loading auxiliary files needed by WeBWorK problems from
 there. However, in production use, that value should be changed, and then
 the `aud` setting provided to the edX system via "Other course settings"
 should also be modified in the same manner.
 
-Now create a `docker-compose.yml` file for the Standaline renderer.
+Now create a `docker-compose.yml` file for the Standalone renderer.
 Create a file containing the following text:
 ```
 version: '3.5'
@@ -478,7 +477,7 @@ start the renderer after starting up the devstack.
 http://localhost:3000 to see the "local editor" provided by the Standalone
 renderer. Pull request https://github.com/drdrew42/renderer/pull/62
 is intended to close that for "production" mode, so once that gets merged
-some additional configuration will apparently be necessary to reanable that
+some additional configuration will apparently be necessary to reenable that
 feature on the Docker installed Standalone renderer.
 
 ## Configuring the demo course to use the XBlock, and testing a WeBWorK problem
@@ -489,12 +488,12 @@ devstack and Standalone renderer are both up a running.
 ### Configuration:
 
 1. Open in your web browser the page http://localhost:18010/settings/advanced/course-v1:edX+DemoX+Demo_Course
-2. Log in (using devstack defaults) as: `staff@example.com` with the password `esx`
+2. Log in (using devstack defaults) as: `staff@example.com` with the password `edx`
 3. You should be able to scroll down and find the "Other Course Settings" section.
-  - If you are in the settings and it is not there, something went wrong with the changes to enable this feature, either in the `etc/studio.yml` file or in how it was mounted into the Docker container.
-  - If you did not yet stop and restart the containers, that could be the cause of this special section of settings being missing.
+   - If you are in the settings and it is not there, something went wrong with the changes to enable this feature, either in the `etc/studio.yml` file or in how it was mounted into the Docker container.
+   - If you did not yet stop and restart the containers, that could be the cause of this special section of settings being missing.
 4. If you find the "Other Course Settings" section, replace the content with that listed below.
-  - On a production server, if there are already settings, you would need to add the content of the enclosing JSON object into the existing settings, as a new top level key/value pair.
+   - On a production server, if there are already settings, you would need to add the content of the enclosing JSON object into the existing settings, as a new top level key/value pair.
 5. Scroll to find the "Advanced Module List" on this page.
 6. Add "webwork" to the list (by adding `"webwork"` and adding the comma where it is needed).
    <img src="Edx-Devstack-Advanced-Module-List.png" alt="drawing" width="500"/>

--- a/install-docs/setup-devstack-named-release-with-webwork-xblock.md
+++ b/install-docs/setup-devstack-named-release-with-webwork-xblock.md
@@ -1,0 +1,629 @@
+## Background
+Testing the WeBWorK XBlock requires:
+  1. A functioning installation of edX with the XBlock installed.
+  2. A suitable "remote" WeBWorK server which can render WeBWorK problems
+for the XBlock.
+
+The goal of this guide is to set up an functional test system using the Docker
+based edX devstack with the webwork XBlock installed it in, and a local install
+of the WeBWorK standalone renderer.
+
+In order to make this test system reasonably stable, the devstack is being set
+using to use the most recent named release (Lilac) of edX and not the `master`
+branch of the devstack, which frequently changes.
+
+This file is based on earlier instructions in
+https://github.com/Technion-WeBWorK/xblock-webwork/blob/master/install-docs/setup-devstack-docker-with-webwork-xblock.md
+which were not fully complete, and which did install a named release of edX
+in the devstack.
+
+## Hardware / software requirements
+
+The installation of the edx devstack depends on using Docker.
+
+The devstack requirements at https://github.com/edx/devstack#prerequisites
+lists Python 3.8 as a prerequisite, and Ubuntu 20.04 LTS provides this
+version of Python by default and is well supported by Docker.
+As a result, this guide assumes that installation will be done in Ubuntu 20.04
+LTS.
+
+Docker for Ubuntu, requires a 64-bit version of Ubuntu. (See https://docs.docker.com/engine/install/ubuntu/#prerequisites).
+
+The requirements also state that Docker for Windows is **not** supported.
+
+Use of different Linux distributions or Mac should be possible, but suitable
+changes in the procedure will be needed.
+
+### Hardware resources:
+
+The devstack requirements at https://github.com/edx/devstack#prerequisites
+provided the following guidance about system resources for using the devstack:
+
+> We find that configuring Docker for Mac with a minimum of 2 CPUs, 8GB of memory, and a disk image size of 96GB does work.
+
+We have been able to install the necessary portion of the devstack to test
+the XBlock and the additional components on a test system which had 16GB RAM
+using a Ubuntu partition of 50GB, and only about 30GB of disk space was used.
+However, that installation did not install the full devstack, only Studio
+and LMS and theie dependencies. A full devstack would certainly use more space.
+
+## Assumptions in the process below.
+
+We assume that you are working in Ubuntu 20.04 and have an active
+internet connection to allow package installation and other downloads.
+
+We assume that the system was configured suitable to be able to install
+packages from the Ubuntu repositories, and that your account can use
+`sudo`.
+
+## Install some additional Ubuntu packages and Python virtualenv
+
+We first install some necessary packages and the Python virtualenv.
+You may prefer to add some additional editor, if you are not comfortable with
+`vim`.
+
+```
+sudo -s
+apt-get update
+apt-get -y install git python3-pip vim
+pip3 install virtualenv
+exit # Leave sudo
+```
+
+Check that Python 3.8 or later is installed:
+```
+python3 --version
+```
+
+## Install Docker and docker-compose
+
+The steps below work as of when this guide was written, and are copied on
+the Docker documentation site. If necessary, refer to the official
+documentation:
+  - https://docs.docker.com/engine/install/ubuntu/
+  - https://docs.docker.com/engine/install/linux-postinstall/
+  - https://docs.docker.com/compose/install/
+for explanations, details, updates, etc.
+
+The commands to run:
+```
+sudo -s
+apt-get update
+apt-get -y install apt-transport-https ca-certificates curl gnupg lsb-release
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io
+
+groupadd docker
+
+curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
+exit # Leave sudo
+
+# Add your regular user to the docker group
+sudo usermod -aG docker $USER
+```
+
+### Using Docker without sudo.
+
+The `docker` group was created to allow you to run Docker commands
+as your regular user. (This has security implications. See the Docker
+documentation.)
+
+That change is not fully active in your current login sesssion.
+
+It is often easiest to log out and the log back in, so that the system will
+be aware that your user belongs to the `docker` group.
+
+Alternatively, you can run `newgrp docker` which should set the group in
+the current terminal.
+
+### Test that Docker works
+
+Test that docker is working (for the current user):
+```
+# If necessary run:
+#           newgrp docker
+docker run hello-world  
+# You should see the output from the test hello-world container.
+```
+
+## Install the edX devstack for the lilac named release.
+
+### Primary sources:
+
+- The instructions below install under `~/XblockEx` which can be changed.
+- The official install instructions for devstack are at: 
+  - https://github.com/edx/devstack
+0 
+- Documentation on install a named release of edX in the devstack are at
+  - //github.com/edx/devstack/blob/master/docs/developing_on_named_release_branches.rst
+  - **Warning:** The older instructions about this at https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-hawthorn.master/installation/install_devstack.html are apparently somewhat outdated, and the order of several steps there seem to be **incorrect**.
+- However, in order to save on resources, this guide does not install a full
+devstack, and only installs the portions needed for using and testing the
+WeBWorK XBlock.
+
+### Setting OPENEDX_RELEASE for the future:
+
+Using devstack with a named release requires that the `OPENEDX_RELEASE` 
+environment variable be set before various commands are run. This is necessary
+both for the installation process, and in later use.
+
+Thus, please add the `export OPENEDX_RELEASE=lilac.master` line (included 
+in the steps below) into your `.bashrc` file (or whatever file/command is
+needed if you are using a different shell) either now or after completing the
+installation. That will make the correct setting of this environment variable
+automatically each time you open a new terminal, etc.
+
+**Note:** If you are working with multiple devstacks, you will need to set
+the `OPENEDX_RELEASE` variable suitably when changing between devstacks.
+
+### Doing the devstack install
+
+Run the following steps as your regular user.
+  - Many of these steps take quite a bit of time to run.
+
+We first create and then start up the Python virtualenv we will be using.
+You will need to start it up also in the future (skipping the `mkdir`).
+```
+mkdir -p ~/XblockEx/edx-devstack
+cd ~/XblockEx/edx-devstack
+
+virtualenv venv
+source venv/bin/activate
+```
+
+Now we install the devstack (using the "lilac" named release of edX):
+
+```
+git clone https://github.com/edx/devstack.git
+cd devstack
+
+make requirements
+make dev.clone.https
+
+# Change NOW to use the "lilac" named release:
+git checkout open-release/lilac.master
+export OPENEDX_RELEASE=lilac.master
+
+# The next command needs to be run after setting OPENEDX_RELEASE
+make dev.checkout
+```
+
+The next step takes some time. Sometimes errors occur during the next step,
+and that indicated that some of the devstack Docker image failed to 
+be downloaded / installed. This seems to be caused by network issues, and
+gets resolved by running the command again. Thus, if you got any error,
+please run the command again (possibly several times) until all images are
+properly downloaded.
+
+```
+# This is where we install only the needed part of devstack
+# instead of using "make dev.pull.large-and-slow" as in the main
+# install instructions
+
+make dev.pull.lms+studio
+```
+
+Reminder: If you get any errors from the last step, run it again until all
+the Docker images are properly downloaded.
+
+---
+
+** The next step is known to take quite a bit of time.** After starting it, you
+probably want to go do something else for a while (probably at least half an
+hour).
+
+** Alternatively, you might want to try to run the "Standalone render"
+installation from 2 sections down in parallel to the next command.
+
+```
+make dev.provision.lms+studio
+```
+
+When that last step ends, you should see a report that
+> Provisioning complete!
+
+## Do some local configuration for the XBlock installation in your devstack
+
+The WeBWorK XBlock depends on using the "Other course settings" optional
+feature to provide course-wide settings. As a result, this feature needs to
+be enabled (for Studio and LMS) in the devstack.
+
+See:
+  - https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_custom_course_settings.html
+  - https://www.edunext.co/articles/discover-open-edx-ironwood/
+  - https://openedx.atlassian.net/browse/OSPR-2303
+
+For the devstack, the setting seems to need to be set in 2 files, as explained
+below.
+
+You should run the following steps while the devstack is still running
+(so you can copy the files out of the running containers to make 
+persistant local copies to edit). Do so inside the Python virtualenv which 
+should still be running from the prior stage (or start up the venv again).
+
+```
+cd ~/XblockEx/edx-devstack/devstack
+mkdir etc
+docker cp edx.devstack-lilac.master.studio:/edx/etc/studio.yml etc/studio.yml
+docker cp edx.devstack-lilac.master.studio:/edx/etc/lms.yml etc/lms.yml
+
+cp etc/studio.yml etc/studio.yml.ORIG
+cp etc/lms.yml etc/lms.yml.ORIG
+```
+
+Open the 2 files with your editor of choice, and add a new line
+`ENABLE_OTHER_COURSE_SETTINGS: true` inside the `FEATURES` section of both
+files.
+
+```
+vim etc/studio.yml etc/lms.yml
+# Add the needed line to both files
+```
+
+Now, we modify the relevant `docker-compose-*.yml` files to use our
+modified copies. First make backup copies of the files we are about to
+edit, and then edit them with your editor of choice (`vim` below).
+
+```
+cp -a docker-compose-host.yml docker-compose-host.yml.ORIG
+cp -a docker-compose-host-nfs.yml docker-compose-host-nfs.yml.ORIG
+
+vim docker-compose-host.yml docker-compose-host-nfs.yml
+```
+
+Find the lines which mount "volumes" into the lms. The relevant lines
+follow the lines
+```
+  lms:
+    volumes:
+```
+and add the following 2 new lines below what is already listed:
+```
+      - "./etc/lms.yml:/edx/etc/lms.yml"
+      - "./etc/studio.yml:/edx/etc/studio.yml"
+```
+
+Now find the lines for the studio "volumes" and add those same 2 lines at the
+end of the list.
+
+These changes are made in both files.
+
+Now restart the Studio and LMS containers (commands to be run in the `venv`):
+
+```
+make dev.down.lms+studio
+make dev.up.lms+studio
+```
+
+Note: It takes some time (typically close to a minute on my machine) for the
+containers to get fully started after the command itself "finishes". That time
+is needed for the container to fully start up everything it needs.
+
+You can check the status of the container startup process by checking what is
+report in the logs using the commands
+```
+docker logs edx.devstack-lilac.master.studio
+docker logs edx.devstack-lilac.master.lms
+```
+
+Hopefully you will now be able to open http://localhost:18000 in your web
+browser and see something like:
+    <img src="Edx-Devstack-Entry-Page.png" alt="drawing" width="500"/>  
+
+## Install the WeBWorK XBlock and configure devstack to load it
+
+Now we  will install the XBlock code, and modify the devstack setup to
+load it.
+
+First install the code from the repository. (These lines need not be run
+in the Python venv)
+
+```
+cd ~/XblockEx/edx-devstack/edx-platform/
+mkdir src
+cd src
+git clone https://github.com/Technion-WeBWorK/xblock-webwork.git
+```
+
+Next we are going to edit the devstack `docker-compose.yml` file so
+the devstack will reinstall and load the XBlock each time the devstack is
+brought up. This is necessary if the code is being modified. (You can use a
+differerent editor instead of `vim` but be careful not to break the required
+formatting of the files being edited.)
+
+
+```
+cd ~/XblockEx/edx-devstack/devstack
+cp -a docker-compose.yml docker-compose.yml.ORIG
+vim docker-compose.yml
+```
+
+1. Find the "command" line in the "lms:" section of the file.
+2. Make the copy of the original line into a commented out line 
+by adding a `#` at the start of the line.
+3. In the active "command" line add the string `pip install /edx/app/edxapp/edx-platform/src/xblock-webwork/ &&` just before the `while true`.
+  - The `pip install` we added should be between an old `&&` and the new one added here.
+4. Repeat this process in the "studio:" section of the file.
+
+**Note:** If you want to use the IDE debugging features discussed in 
+https://github.com/Technion-WeBWorK/xblock-webwork/blob/master/install-docs/devstack-install-and-debug.md
+you would also want to add `pip install ptvsd` in a similar manner.
+As this guide is not addressing IDE debugging, that additional install is not
+required in the "command" lines we edited above.
+
+Restart the devstack, by running the following lines in the "venv":
+```
+make dev.down.lms+studio
+make dev.up.lms+studio
+```
+
+## Install and configure a local installation of the WeBWorK standalone renderer
+
+This step is somewhat independed of the prior 2 steps, and could be done
+in parallel to them, so long as the additional network load will not 
+interfere with the other installation steps.
+
+### Installation:
+
+The installation directory `~/Render` is used below, but can be changed.
+
+The process is essentially that from the `README.md` at
+https://github.com/drdrew42/renderer
+but we add local configuration files and enable using `docker-compose` to
+start and stop the renderer.
+
+Run the following commands in a new terminal window.
+  - If you did not log out after adding your user to the `docker` group, you
+    will probably need to run `newgrp docker` before using docker commands
+    below.
+
+```
+mkdir ~/Render
+cd ~/Render
+
+mkdir volumes
+mkdir container
+git clone https://github.com/openwebwork/webwork-open-problem-library volumes/webwork-open-problem-library
+git clone --recursive https://github.com/drdrew42/renderer container/
+
+# If needed use
+#     newgrp docker
+
+docker build --tag renderer:1.0 ./container
+
+### Customized configuration:
+
+# Create render_app.conf
+cp container/render_app.conf.dist render_app.conf
+```
+
+Next we edit `render_app.conf`:
+```
+vim render_app.conf
+```
+and replace the value of `problemJWTsecret` with a sample value which will
+work.
+  - The python side JWT code in use by the XBlock requires that the value
+    be a 32-octet "string". Since it is ready in both on the edX side and on
+    the Standalone renderer side from a string, we recommend using only 7-bit
+    ASCII characters, to avoid any problems with character-set related
+    conversions leading to the value not being properly received.
+  - For the sample testing, please use 
+    `problemJWTsecret => 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'` or make sure to
+     set the same value in this file and in the configration later added to 
+     the "Other course settings" in edX Studio.
+
+**Warning:** for local use of the Standalone renderer with edX devstack
+on a single computer, you should **not** replace the value of `SITE_HOST`
+in the `render_app.conf` file. It should remain `http://localhost:3000` as
+your browser will be loading auxilliary files needed by WeBWorK problems from
+there. However, in production use, that value should be changed, and then
+the `aud` setting provided to the edX system via "Other course settings"
+should also be modified in the same manner.
+
+Now create a `docker-compose.yml` file for the Standaline renderer.
+Create a file containing the following text:
+```
+version: '3.5'
+networks:
+  default:
+    external:
+      name: devstack-lilacmaster_default
+
+services:
+  renderer:
+    image: renderer:1.0
+
+    volumes:
+      # Local config file
+      - "./render_app.conf:/usr/app/render_app.conf"
+      # OPL
+      - "./volumes/webwork-open-problem-library:/usr/app/webwork-open-problem-library"
+    # END volumes
+
+    hostname: wwstandalone
+
+    ports:
+      - "3000:3000"
+```
+
+The "special" settings made here are:
+  1. Attaching the Standalone render to the Docker `devstack-lilacmaster_default` network, which is the Docker network devstack will use the "lilac" named release.
+  2. Naming the container as "wwstandalone" which will be used also in the "Other course settings" configuration on the edX side.
+  3. Using the local `render_app.conf` we just created.
+
+### How to start/stop the renderer
+
+Now we can start up the Standalone renderer as follows:
+```
+cd ~/Render ; docker-compose up -d
+```
+and stop it (when needed) using
+```
+cd ~/Render ; docker-compose down
+```
+
+The configuration assumes that the necessary Docker network exists,
+and it created when the devstack is brought up. Thus, it is simplest to
+start the renderer after starting up the devstack.
+
+**Note:** At present, once the renderer is running, you should be able to open
+http://localhost:3000 to see the "local editor" provided by the Standalone
+renderer. Pull request https://github.com/drdrew42/renderer/pull/62
+is intended to close that for "production" mode, so once that gets merged
+some additional configuration will apparently be necessary to reanable that
+feature on the Docker installed Standalone renderer.
+
+## Configuring the demo course to use the XBlock, and testing a WeBWorK problem
+
+We assume that all prior steps were successfully completed, and that the
+devstack and Standalone renderer are both up a running.
+
+### Configuration:
+
+1. Open in your web browser the page http://localhost:18010/settings/advanced/course-v1:edX+DemoX+Demo_Course
+2. Log in (using devstack defaults) as: `staff@example.com` with the password `esx`
+3. You should be able to scroll down and find the "Other Course Settings" section.
+  - If you are in the settings and it is not there, something went wrong with the changes to enable this feature, either in the `etc/studio.yml` file or in how it was mounted into the Docker container.
+  - If you did not yet stop and restart the containers, that could be the cause of this special section of settings being missing.
+4. If you find the "Other Course Settings" section, replace the content with that listed below.
+  - On a production server, if there are already settings, you would need to add the content of the enclosing JSON object into the existing settings, as a new top level key/value pair.
+5. Scroll to find the "Advanced Module List" on this page.
+6. Add "webwork" to the list (by adding `"webwork"` and adding the comma where it is needed).
+   <img src="Edx-Devstack-Advanced-Module-List.png" alt="drawing" width="500"/>
+7. Save the settings.
+
+#### Sample settings for "Other Course Settings"
+```
+{
+    "webwork_settings": {
+        "server_settings": {
+            "LocalStandAloneWW": {
+                "server_type": "standalone",
+                "server_api_url": "http://wwstandalone:3000/render-api",
+                "auth_data": {
+                    "aud": "http://localhost:3000",
+                    "problemJWTsecret": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                }
+            }
+        },
+        "course_defaults": {
+            "default_server": "LocalStandAloneWW",
+            "psvn_shift": 51
+        }
+    }
+}
+
+```
+
+### Adding a test WeBWorK problem:
+
+1. Click on "Content" and select "Outline" in your browser tab.
+2. Add a new subsection to week 1 called "WeBWorK problems".
+3. Add a new unit to that subsection.
+4. The browser should automatically open the page for the new unit.
+5. Scroll down and Click on "Advanced" in "Add New Component" (at the bottom of the page) and then on "WeBWorK problem".
+   <img src="Edx-Devstack-Add-New-Component.png" alt="drawing" width="500"/>
+
+The problem you add will report:
+```
+  WeBWorK Problem
+  An unexpected error occurred!
+```
+and inside the iFrame:
+```
+  Your problem should load soon.
+  Please wait.
+```
+
+This occurs when a new instance of the XBlock is added, because some settings
+are properly set only after the problem settings are edited. In typical use,
+the default value for the problem to give are not what would be needed, so this
+"bug" does not seem critical.
+
+Now click "Edit" on the "bar" above the problem, and then just "Save" the
+settings.
+
+The problem should now render. If not, first make sure that the Standalone
+renderer Docker container is running, if so have a look at the Docker logs for
+the container. Also check that the settings are correct on both sides, and in
+particular that the same value for `problemJWTsecret` is in use by both
+systems.
+
+Now try to add a second problem, and change the value of "Problem" to the
+path to a different OPL problem (or something else available to the
+renderer you are using). For example, you can try
+`Library/UBC/setDerivatives/differentiability1.pg` which was picked quite
+arbitrarily.
+
+Try interacting with these problems.
+
+You can edit them to set limits on the number of attempts allowed, etc.
+
+"Publish" the unit.
+
+Now click "View live version" and the unit should open in the LMS (port 18000).
+
+### Some things you can try out
+
+If you add WeBWorK problems to a section with a deadline, the behavior of the
+problem should change before the deadline (and course grade period) pass, and
+then get locked for the number of hours set in the post_deadline_lockdown
+setting of the problem, and then reopen for additional use which is not for
+credit.
+
+In the post-lockdown period, correct answers should be available
+unless the "allow_show_answers" of the problem was changed to false.
+When there is no deadline, correct answers should become available
+after the permitted number if graded attempts is exhausted (or if unlimited,
+after the number of attempts set in the problem setting
+`no_attempt_limit_required_attempts_before_show_answers` which defaults to 10
+attempts).
+
+## Startup and Shutdown procedures
+
+### Startup
+
+1. Start venv if needed, if running change to the correct window with the `venv`
+```
+cd ~/XblockEx/edx-devstack
+virtualenv venv
+source venv/bin/activate
+```
+2. In the `venv`:
+```
+cd ~/XblockEx/edx-devstack/devstack ; make dev.up.lms+studio
+```
+3. In a DIFFERENT terminal (not in the `venv`) start the Standalone renderer
+```
+cd ~/Render ; docker-compose up -d
+```
+4. Wait until the edX devstack is fully up before accessing edX pages in browser
+  - You can run `docker logs edx.devstack-lilac.master.studio` and/or
+    `docker logs edx.devstack-lilac.master.lms` to check the progress.
+
+### Shutdown
+
+1. Stop the Standalone renderer. This command does not need to be in the `venv`:
+```
+cd ~/Render ; docker-compose down
+```
+2. Start venv if needed, if running change to the correct window with the `venv`
+```
+cd ~/XblockEx/edx-devstack
+virtualenv venv
+source venv/bin/activate
+```
+3. In the `venv`:
+```
+cd ~/XblockEx/edx-devstack/devstack ; make dev.down
+```
+
+


### PR DESCRIPTION
Add install instructions using an edX named release.
Modify the files in `doc/` which were quite outdated.
Added the `doc/Design.md` design doc.
Added some comments about the need for "Other course settings" and the problem with the "master" devstack branch to the older install documentation files.