### PR TITLE
Minor style change to enclosing HTML/CSS for the WeBWorK content

### DIFF
--- a/webwork/static/css/webwork.css
+++ b/webwork/static/css/webwork.css
@@ -1,7 +1,11 @@
 /* CSS for WeBWorKXBlock */
 
-
 div.webwork_block {
     border:2px solid black;
     padding: 4px;
+}
+
+div.webwork_iframe_container {
+    width: calc(100% - 12px);
+    padding: 0px;
 }

--- a/webwork/static/html/webwork_in_iframe.html
+++ b/webwork/static/html/webwork_in_iframe.html
@@ -5,9 +5,9 @@
         <div id="edx_message-{unique_id}"></div>
         <div id="edx_webwork_result-{unique_id}"></div>
 
-        <div id="edx_webwork_problem">
+        <div id="edx_webwork_problem" class="webwork_iframe_container">
           <div id='render-contents' class='content'>
-            <iframe class="iframe-responsive" id="rendered-problem-{unique_id}" title="WeBWorK problem" style="width: 100%;" srcdoc="{srcdoc}">
+            <iframe class="iframe-responsive" id="rendered-problem-{unique_id}" title="WeBWorK problem" srcdoc="{srcdoc}">
                  Problem should load here soon.
             </iframe>
             {iFrameInit}


### PR DESCRIPTION
Before this patch, in studio, the webwork question would slightly stick out of the left side of the black border, even when there was sufficient width to hold the width set using the minimum iframe with set via the XBlock.

![problem-sticking-out-on-left](https://user-images.githubusercontent.com/39089094/128682218-fa1c2886-b27c-4a8f-9a1f-4a4d9015cf9b.png)

After this change, that is not happening.