### PR TITLE
Use POST instead of GET for requests to an html2xml server, use data instead of params for both server types

### DIFF
--- a/webwork/webwork.py
+++ b/webwork/webwork.py
@@ -1100,7 +1100,7 @@ class WeBWorKXBlock(
         my_res = None
         if my_url:
             try:
-                my_res = requests.post(my_url, params=dict(
+                my_res = requests.post(my_url, data=dict(
                         params,
                         courseID=my_auth_data.get('ww_course','error'),
                         userID=my_auth_data.get('ww_username','error'),
@@ -1182,7 +1182,7 @@ class WeBWorKXBlock(
         if my_url:
             try:
                 my_res = requests.post(my_url,
-                    params=dict(params,
+                    data=dict(params,
                         # standalone does not have course/user/password
                         # The following fields are not in the JWT and should only be there
                         #problemSeed=str(self.seed),

--- a/webwork/webwork.py
+++ b/webwork/webwork.py
@@ -1092,7 +1092,7 @@ class WeBWorKXBlock(
             request.pop(key, None)
 
     def request_webwork_html2xml(self, params):
-        # html2xml uses HTTP GET
+        # html2xml can use HTTP GET or POST. POST is more secure
         # See https://requests.readthedocs.io/en/master/user/quickstart/#make-a-request
         my_timeout = max(self.webwork_request_timeout,0.5)
         my_url = self.current_server_settings.get("server_api_url")
@@ -1100,7 +1100,7 @@ class WeBWorKXBlock(
         my_res = None
         if my_url:
             try:
-                my_res = requests.get(my_url, params=dict(
+                my_res = requests.post(my_url, params=dict(
                         params,
                         courseID=my_auth_data.get('ww_course','error'),
                         userID=my_auth_data.get('ww_username','error'),


### PR DESCRIPTION
The code was using HTTP `GET` to send requests to `html2xml` servers from the early days. `POST` is considered more secure and also works, and allows for the data being sent to be larger. This PR changes to using `POST`.

The requests to standalone renderers already used `POST`, but was including the "form data" in the URL string, just as `GET` does.

This PR change the code for calls to both backends to send the data using `data` (sent as form-data in the body of the `POST` request) and not `params` (which is added to the URL and can be logged by Apache for html2xm, etc.) to keep all the submission data more secure.

Note: Python's `requests` library does not make it simple to force the `POST` request to use the "multipart form data" style when there are no "files". Some articles suggest that format may be preferable when there are many characters which need URL encoding when sent via `x/www-form-urlencoded`. However, that does not seem to be a major factor, as most answers remain in 7-bit ASCII, and the few special characters (like '/') which will need url-encoding are probably a relatively small portion of the full data being sent.

Some workarounds to force multi-part encoding are mentioned in
  - https://stackoverflow.com/a/63798946
  - https://franklingu.github.io/programming/2017/10/30/post-multipart-form-data-using-requests/
and such an approach can be considered in the future.