### PR TITLE
Fix missing grades in progress page - for ginkgo-fixes branch

### DIFF
--- a/webwork/webwork.py
+++ b/webwork/webwork.py
@@ -1362,6 +1362,25 @@ class WeBWorKXBlock(
         """
         return self.max_allowed_score
 
+    # The edX grading infrastructure expects there to be a max_score method,
+    # and without one, a WeBWorK problem which was not yet submitted (for credit)
+    # will not appear in the "progress page". That is a serious bug.
+    # Also, without the max_score() method error messages were being logged that
+    # "GradesTransformer: max_score is None".
+    #
+    # Commit 1e453d4b74a9d5d3d18cded5c6d88b96156d8651 changed the max_score() method to
+    # get_max_score() as that makes its usage clearer elsewhere in this XBlock.
+    # We are adding a second copy with the expected name, as needed by core edX code.
+    #
+    # See: https://github.com/edx/edx-platform/blob/master/lms/djangoapps/grades/transformer.py#L152
+    # and: https://github.com/edx/edx-platform/blob/master/lms/djangoapps/grades/scores.py#L233
+    # See also: https://github.com/edx/edx-platform/pull/13655
+    def max_score(self):
+        """
+        Get the max score
+        """
+        return self.max_allowed_score
+
     def resource_string(self, path):
         """
         Handy helper for getting resources from our kit.


### PR DESCRIPTION
Fix a major bug. Before this PR, grades for WeBWorK problems would appear in the progress page only after a for-credit submission was made.
That was because the max_grade() method was missing (renamed in the past).
Once the method was defined again, the problems do appear in the progress page even before they are submitted.