### PR TITLE
Avoid error in celery worker about non-lazy gettext calls at import time (same as PR#17 but for master)

### DIFF
--- a/webwork/webwork.py
+++ b/webwork/webwork.py
@@ -50,7 +50,12 @@ from django.utils.translation import ugettext_lazy as _ # pylint: disable=import
 # and was patched for that XBlock in https://github.com/mitodl/edx-sga/pull/254 .
 # Their fix replaced "import ugettext_lazy" with "import ugettext" above for _ totally.
 # We want to keep ugettext_lazy for help strings, so instead add:
-from django.utils.translation import ugettext as non_lazy_ugettext # pylint: disable=import-error
+#
+# 2021-12-01 the use of non_lazy_ugettext is making trouble
+# for celery worked on the production systems (on AWS).
+# Try dropping it, and remove request to translate defaults
+# which used it.
+#from django.utils.translation import ugettext as non_lazy_ugettext # pylint: disable=import-error
 
 # from django.utils import translation # FIXME remove after debug i18n-try1 branch
 
@@ -678,7 +683,12 @@ class WeBWorKXBlock(
        # for a discussion about a similar error in SGA XBlock.
        # Since we want to continue to enable lazy translations of the help strings,
        # we use non_lazy_ugettext
-       default = non_lazy_ugettext("WeBWorK Problem"),
+       # 2021-12-01 the use of non_lazy_ugettext is making trouble
+       # for celery worked on the production systems (on AWS).
+       # Try dropping it, and remove request to translate defaults
+       # which used it.
+       #default = non_lazy_ugettext("WeBWorK Problem"),
+       default = "WeBWorK Problem",
        scope = Scope.settings,
        help = _("Display name which appears in the control bar above the content in Studio view.") # Where else?
        #help=_("This name appears in the horizontal navigation at the top of the page."),
@@ -687,7 +697,12 @@ class WeBWorKXBlock(
     problem_banner_text = String(
        display_name = _("Problem Banner Text"),
        # non_lazy_ugettext also here
-       default = non_lazy_ugettext("WeBWorK Problem"),
+       # 2021-12-01 the use of non_lazy_ugettext is making trouble
+       # for celery worked on the production systems (on AWS).
+       # Try dropping it, and remove request to translate defaults
+       # which used it.
+       #default = non_lazy_ugettext("WeBWorK Problem"),
+       default = "WeBWorK Problem",
        scope = Scope.settings,
        help=_("This text appears as an H3 header above the problem."),
     )


### PR DESCRIPTION
This is the change of https://github.com/Technion-WeBWorK/xblock-webwork/pull/17 but cherry-picked to master (for Koa and on) as https://github.com/Technion-WeBWorK/xblock-webwork/pull/17 was for the ginkgo-fixes branch.

---
There was a report of problems in the production system (on Ginkgo), and an error message was logged referring to the WeBWorK XBlock. Error logged:
```
AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.
Nov 29 08:39:47 ip-10-12-72-138 [service_variant=lms][xblock.plugin][env:prod-olivex-edxapp] WARNING [ip-10-12-72-138  2117] [plugin.py:149] - Unable to load XBlock 'webwork'
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/plugin.py", line 146, in load_classes
    yield (class_.name, cls._load_class_entry_point(class_))
```
The code with `non_lazy_ugettext` was working fine in the LMS and CMS code, in that WeBWorK problems could be added and used using the XBlock before the code change in the PR.

The problem is in the celery workers, but it was discovered that those servers had a configuration error.

In any case, the change in this PR attempts to avoid the error reported by avoiding use of `non_lazy_ugettext` for the default values and just not translating them. (Values can be set manually as desired.)