### PR TITLE
Checkbox fix

### DIFF
--- a/webwork/static/js/src/webwork_in_iframe.js
+++ b/webwork/static/js/src/webwork_in_iframe.js
@@ -4,12 +4,14 @@ function WeBWorKXBlockIframed(runtime, element, initdata) {
 
     var handlerUrl = runtime.handlerUrl(element, 'submit_webwork_iframed');
 
-    console.log("I was sent rpID ", initdata.rpID);
-    console.log("I was sent messDivID ", initdata.messageDivID);
-    console.log("I was sent resultDivID ", initdata.resultDivID);
-    console.log("All initdata = ", initdata);
+    /*
+      console.log("I was sent rpID ", initdata.rpID);
+      console.log("I was sent messDivID ", initdata.messageDivID);
+      console.log("I was sent resultDivID ", initdata.resultDivID);
+      console.log("All initdata = ", initdata);
 
-    console.log("handlerUrl is ", handlerUrl);
+      console.log("handlerUrl is ", handlerUrl);
+    */
 
     let problemiframe = document.getElementById(initdata.rpID);
     let messageDiv = document.getElementById(initdata.messageDivID);
@@ -51,22 +53,22 @@ function WeBWorKXBlockIframed(runtime, element, initdata) {
     function hideButtons(result) {
         let problemForm = problemiframe.contentWindow.document.getElementById('problemMainForm')  // don't croak when the empty iframe is first loaded
         if (!problemForm) {
-            console.log('hideButtons: could not find form! has a problem been rendered?');
+            /* console.log('hideButtons: could not find form! has a problem been rendered?'); */
             return;
         }
-        console.log('hideButtons: enabling/disabling show answers');
+        /* console.log('hideButtons: enabling/disabling show answers'); */
         var my_buttons = problemiframe.contentWindow.document.getElementsByName("showCorrectAnswers") // name in standalone
         my_buttons.forEach(button => { button.disabled = hideShowAnswers; })
         my_buttons = problemiframe.contentWindow.document.getElementsByName("WWcorrectAns") // name in html2xml
         my_buttons.forEach(button => { button.disabled = hideShowAnswers; })
 
-        console.log('hideButtons: enabling/disabling preview');
+        /* console.log('hideButtons: enabling/disabling preview'); */
         my_buttons = problemiframe.contentWindow.document.getElementsByName("previewAnswers") // name in standalone
         my_buttons.forEach(button => { button.disabled = hidePreview; })
         my_buttons = problemiframe.contentWindow.document.getElementsByName("preview") // name in html2xml
         my_buttons.forEach(button => { button.disabled = hidePreview; })
 
-        console.log('hideButtons: enabling/disabling submit');
+        /* console.log('hideButtons: enabling/disabling submit'); */
         my_buttons = problemiframe.contentWindow.document.getElementsByName("submitAnswers") // name in standalone
         my_buttons.forEach(button => { button.disabled = hideSubmit; })
         my_buttons = problemiframe.contentWindow.document.getElementsByName("WWsubmit") // name in html2xml
@@ -80,13 +82,13 @@ function WeBWorKXBlockIframed(runtime, element, initdata) {
     function activeButton() {
         let problemForm = problemiframe.contentWindow.document.getElementById('problemMainForm')
         if (!problemForm) {
-            console.log('could not find form! has a problem been rendered?');
+            /* console.log('could not find form! has a problem been rendered?'); */
             return;
         }
         problemForm.querySelectorAll('.btn-primary').forEach(
             button => {
                 button.addEventListener('click', () => {
-                    console.log('clicked: ', button);
+                    /* console.log('clicked: ', button); */
                 })
             })
     }
@@ -98,7 +100,7 @@ function WeBWorKXBlockIframed(runtime, element, initdata) {
     function insertListener() {
         let problemForm = problemiframe.contentWindow.document.getElementById('problemMainForm')  // don't croak when the empty iframe is first loaded
         if (!problemForm) {
-            console.log('could not find form! has a problem been rendered?');
+            /* console.log('could not find form! has a problem been rendered?'); */
             return;
         }
         problemForm.addEventListener('submit', event => {
@@ -170,7 +172,7 @@ function WeBWorKXBlockIframed(runtime, element, initdata) {
     // That code is licensed under GPL 3.0
 
     problemiframe.addEventListener('load', () => {
-        console.log('loaded...' + initdata.rpID);
+        /* console.log('loaded...' + initdata.rpID); */
         activeButton();
         insertListener();
         hideButtons();

--- a/webwork/static/js/src/webwork_in_iframe.js
+++ b/webwork/static/js/src/webwork_in_iframe.js
@@ -120,10 +120,26 @@ function WeBWorKXBlockIframed(runtime, element, initdata) {
 
             let formJsonData = {};
 
-            for (const [key, value] of formDataEntries) {
-                formJsonData[key] = value;
-            }
-            /* End of code based on  https://ilikekillnerds.com/2017/09/convert-formdata-json-object/ */
+            /* The original approach did not send multiple values of checkboxes.
+               Modify based on https://stackoverflow.com/a/49826736
+               from inside the page https://stackoverflow.com/questions/41431322/how-to-convert-formdata-html5-object-to-json
+            */
+
+            formData.forEach(
+              ( value, key ) => {
+                // Check if property already exist
+                if ( Object.prototype.hasOwnProperty.call( formJsonData, key ) ) {
+                  let current = formJsonData[ key ];
+                  if ( !Array.isArray( current ) ) {
+                    // If it's not an array, convert it to an array.
+                    current = formJsonData[ key ] = [ current ];
+                  }
+                  current.push( value ); // Add the new value to the array.
+                } else {
+                  formJsonData[ key ] = value;
+                }
+              }
+            );
 
             $.ajax({
                 type: "POST",


### PR DESCRIPTION
Before this patch (the change in the first commit) checkbox questions were not working properly in the XBlock, as the code to convert the form data in the answer to JSON was only sending the "last" marked answer. Fixed base on the approach from https://stackoverflow.com/a/49826736 so that an array of the marked answers is set.

The second commit just comments out lines which were putting debug data in the JavaScript console, and that data is no longer needed.

This was tested using 
  - `Library/PCC/BasicMath/PrimeLCMGCF/divisibility20.pg`
  - and the sample problem below which has 2 checkbox questions in it.

```
OCUMENT();
loadMacros(
  "PGstandard.pl",
  "PGchoicemacros.pl"
);

## creates a new multiple choice set of problems
$mc1 = new_checkbox_multiple_choice();
$mc2 = new_checkbox_multiple_choice();

$mc1->qa(
"",
"true 1",
"true 2",
"true 3",
"true 4"
);
$mc1->extra(
"false 1",
"false 2",
"false 3",
"false 4"
);

$mc2->qa(
"",
"true 1",
"true 2",
"true 3",
"true 4"
);
$mc2->extra(
"false 1",
"false 2",
"false 3",
"false 4"
);

TEXT(beginproblem());

$showPartialCorrectAnswers = 0;

BEGIN_TEXT
\{ $mc1->print_a() \}
$PAR
\{ $mc2->print_a() \}
END_TEXT

ANS( checkbox_cmp( $mc1->correct_ans() ) );
ANS( checkbox_cmp( $mc2->correct_ans() ) );

ENDDOCUMENT();
```